### PR TITLE
Prevent refresh race conditions

### DIFF
--- a/Heimdallr/Core/Heimdallr.swift
+++ b/Heimdallr/Core/Heimdallr.swift
@@ -39,7 +39,7 @@ public let HeimdallrErrorNotAuthorized = 2
         return accessToken != nil
     }
 
-    private var refreshQueue = dispatch_queue_create("de.rheinfabrik.Heimdallr.refeshQueue", DISPATCH_QUEUE_SERIAL)
+    private var requestQueue = dispatch_queue_create("com.trivago.Heimdallr.requestQueue", DISPATCH_QUEUE_SERIAL)
 
     /// Initializes a new client.
     ///
@@ -199,8 +199,8 @@ public let HeimdallrErrorNotAuthorized = 2
     /// - parameter request: An unauthenticated NSURLRequest.
     /// - parameter completion: A callback to invoke with the authenticated request.
     public func authenticateRequest(request: NSURLRequest, completion: Result<NSURLRequest, NSError> -> ()) {
-        dispatch_async(refreshQueue) {
-            self.blockRefreshQueue()
+        dispatch_async(requestQueue) {
+            self.blockRequestQueue()
             self.authenticateRequestConcurrently(request, completion: completion)
         }
     }
@@ -219,7 +219,7 @@ public let HeimdallrErrorNotAuthorized = 2
                             }
                             return .Failure(error)
                         }))
-                        self.releaseRefreshQueue()
+                        self.releaseRequestQueue()
                     }
                 } else {
                     let userInfo = [
@@ -229,12 +229,12 @@ public let HeimdallrErrorNotAuthorized = 2
 
                     let error = NSError(domain: HeimdallrErrorDomain, code: HeimdallrErrorNotAuthorized, userInfo: userInfo)
                     completion(.Failure(error))
-                    releaseRefreshQueue()
+                    releaseRequestQueue()
                 }
             } else {
                 let request = authenticateRequest(request, accessToken: accessToken)
                 completion(.Success(request))
-                releaseRefreshQueue()
+                releaseRequestQueue()
             }
         } else {
             let userInfo = [
@@ -244,15 +244,15 @@ public let HeimdallrErrorNotAuthorized = 2
 
             let error = NSError(domain: HeimdallrErrorDomain, code: HeimdallrErrorNotAuthorized, userInfo: userInfo)
             completion(.Failure(error))
-            releaseRefreshQueue()
+            releaseRequestQueue()
         }
     }
 
-    private func blockRefreshQueue() {
-        dispatch_suspend(refreshQueue)
+    private func blockRequestQueue() {
+        dispatch_suspend(requestQueue)
     }
 
-    private func releaseRefreshQueue() {
-        dispatch_resume(refreshQueue)
+    private func releaseRequestQueue() {
+        dispatch_resume(requestQueue)
     }
 }

--- a/Heimdallr/Core/Heimdallr.swift
+++ b/Heimdallr/Core/Heimdallr.swift
@@ -224,6 +224,9 @@ public let HeimdallrErrorNotAuthorized = 2
                         }))
                     }
                 } else {
+                    defer {
+                        self.releaseRequestQueue()
+                    }
                     let userInfo = [
                         NSLocalizedDescriptionKey: NSLocalizedString("Could not add authorization to request", comment: ""),
                         NSLocalizedFailureReasonErrorKey: NSLocalizedString("Access token expired, no refresh token available.", comment: "")
@@ -231,14 +234,18 @@ public let HeimdallrErrorNotAuthorized = 2
 
                     let error = NSError(domain: HeimdallrErrorDomain, code: HeimdallrErrorNotAuthorized, userInfo: userInfo)
                     completion(.Failure(error))
-                    releaseRequestQueue()
                 }
             } else {
+                defer {
+                    self.releaseRequestQueue()
+                }
                 let request = authenticateRequest(request, accessToken: accessToken)
                 completion(.Success(request))
-                releaseRequestQueue()
             }
         } else {
+            defer {
+                self.releaseRequestQueue()
+            }
             let userInfo = [
                 NSLocalizedDescriptionKey: NSLocalizedString("Could not add authorization to request", comment: ""),
                 NSLocalizedFailureReasonErrorKey: NSLocalizedString("Not authorized.", comment: "")
@@ -246,7 +253,6 @@ public let HeimdallrErrorNotAuthorized = 2
 
             let error = NSError(domain: HeimdallrErrorDomain, code: HeimdallrErrorNotAuthorized, userInfo: userInfo)
             completion(.Failure(error))
-            releaseRequestQueue()
         }
     }
 

--- a/Heimdallr/Core/Heimdallr.swift
+++ b/Heimdallr/Core/Heimdallr.swift
@@ -224,9 +224,6 @@ public let HeimdallrErrorNotAuthorized = 2
                         }))
                     }
                 } else {
-                    defer {
-                        self.releaseRequestQueue()
-                    }
                     let userInfo = [
                         NSLocalizedDescriptionKey: NSLocalizedString("Could not add authorization to request", comment: ""),
                         NSLocalizedFailureReasonErrorKey: NSLocalizedString("Access token expired, no refresh token available.", comment: "")
@@ -234,18 +231,14 @@ public let HeimdallrErrorNotAuthorized = 2
 
                     let error = NSError(domain: HeimdallrErrorDomain, code: HeimdallrErrorNotAuthorized, userInfo: userInfo)
                     completion(.Failure(error))
+                    releaseRequestQueue()
                 }
             } else {
-                defer {
-                    self.releaseRequestQueue()
-                }
                 let request = authenticateRequest(request, accessToken: accessToken)
                 completion(.Success(request))
+                releaseRequestQueue()
             }
         } else {
-            defer {
-                self.releaseRequestQueue()
-            }
             let userInfo = [
                 NSLocalizedDescriptionKey: NSLocalizedString("Could not add authorization to request", comment: ""),
                 NSLocalizedFailureReasonErrorKey: NSLocalizedString("Not authorized.", comment: "")
@@ -253,6 +246,7 @@ public let HeimdallrErrorNotAuthorized = 2
 
             let error = NSError(domain: HeimdallrErrorDomain, code: HeimdallrErrorNotAuthorized, userInfo: userInfo)
             completion(.Failure(error))
+            releaseRequestQueue()
         }
     }
 

--- a/Heimdallr/Core/Heimdallr.swift
+++ b/Heimdallr/Core/Heimdallr.swift
@@ -210,6 +210,9 @@ public let HeimdallrErrorNotAuthorized = 2
             if accessToken.expiresAt != nil && accessToken.expiresAt < NSDate() {
                 if let refreshToken = accessToken.refreshToken {
                     requestAccessToken(grant: .RefreshToken(refreshToken)) { result in
+                        defer {
+                            self.releaseRequestQueue()
+                        }
                         completion(result.analysis(ifSuccess: { accessToken in
                             let authenticatedRequest = self.authenticateRequest(request, accessToken: accessToken)
                             return .Success(authenticatedRequest)
@@ -219,7 +222,6 @@ public let HeimdallrErrorNotAuthorized = 2
                             }
                             return .Failure(error)
                         }))
-                        self.releaseRequestQueue()
                     }
                 } else {
                     let userInfo = [

--- a/Heimdallr/Core/Heimdallr.swift
+++ b/Heimdallr/Core/Heimdallr.swift
@@ -202,6 +202,7 @@ public let HeimdallrErrorNotAuthorized = 2
     public func authenticateRequest(request: NSURLRequest, completion: Result<NSURLRequest, NSError> -> ()) {
         dispatch_sync(refreshQueue) {
             self.blockRefreshQueue()
+            print("started authentication")
             self.authenticateRequestConcurrently(request, completion: completion)
         }
     }
@@ -250,10 +251,10 @@ public let HeimdallrErrorNotAuthorized = 2
     }
 
     private func blockRefreshQueue() {
-        dispatch_semaphore_wait(self.refreshSemaphore, DISPATCH_TIME_FOREVER)
+        dispatch_semaphore_wait(refreshSemaphore, DISPATCH_TIME_FOREVER)
     }
 
     private func releaseRefreshQueue() {
-        dispatch_semaphore_signal(self.refreshSemaphore)
+        dispatch_semaphore_signal(refreshSemaphore)
     }
 }

--- a/Heimdallr/Core/Heimdallr.swift
+++ b/Heimdallr/Core/Heimdallr.swift
@@ -199,7 +199,7 @@ public let HeimdallrErrorNotAuthorized = 2
     /// - parameter request: An unauthenticated NSURLRequest.
     /// - parameter completion: A callback to invoke with the authenticated request.
     public func authenticateRequest(request: NSURLRequest, completion: Result<NSURLRequest, NSError> -> ()) {
-        dispatch_sync(refreshQueue) {
+        dispatch_async(refreshQueue) {
             self.blockRefreshQueue()
             print("started authentication")
             self.authenticateRequestConcurrently(request, completion: completion)

--- a/Heimdallr/Core/Heimdallr.swift
+++ b/Heimdallr/Core/Heimdallr.swift
@@ -40,7 +40,6 @@ public let HeimdallrErrorNotAuthorized = 2
     }
 
     private var refreshQueue = dispatch_queue_create("de.rheinfabrik.Heimdallr.refeshQueue", DISPATCH_QUEUE_SERIAL)
-    private let refreshSemaphore = dispatch_semaphore_create(1)
 
     /// Initializes a new client.
     ///
@@ -251,10 +250,10 @@ public let HeimdallrErrorNotAuthorized = 2
     }
 
     private func blockRefreshQueue() {
-        dispatch_semaphore_wait(refreshSemaphore, DISPATCH_TIME_FOREVER)
+        dispatch_suspend(refreshQueue)
     }
 
     private func releaseRefreshQueue() {
-        dispatch_semaphore_signal(refreshSemaphore)
+        dispatch_resume(refreshQueue)
     }
 }

--- a/Heimdallr/Core/Heimdallr.swift
+++ b/Heimdallr/Core/Heimdallr.swift
@@ -210,9 +210,6 @@ public let HeimdallrErrorNotAuthorized = 2
             if accessToken.expiresAt != nil && accessToken.expiresAt < NSDate() {
                 if let refreshToken = accessToken.refreshToken {
                     requestAccessToken(grant: .RefreshToken(refreshToken)) { result in
-                        defer {
-                            self.releaseRequestQueue()
-                        }
                         completion(result.analysis(ifSuccess: { accessToken in
                             let authenticatedRequest = self.authenticateRequest(request, accessToken: accessToken)
                             return .Success(authenticatedRequest)
@@ -222,6 +219,7 @@ public let HeimdallrErrorNotAuthorized = 2
                             }
                             return .Failure(error)
                         }))
+                        self.releaseRequestQueue()
                     }
                 } else {
                     let userInfo = [

--- a/Heimdallr/Core/Heimdallr.swift
+++ b/Heimdallr/Core/Heimdallr.swift
@@ -201,7 +201,6 @@ public let HeimdallrErrorNotAuthorized = 2
     public func authenticateRequest(request: NSURLRequest, completion: Result<NSURLRequest, NSError> -> ()) {
         dispatch_async(refreshQueue) {
             self.blockRefreshQueue()
-            print("started authentication")
             self.authenticateRequestConcurrently(request, completion: completion)
         }
     }

--- a/HeimdallrTests/Core/HeimdallrSpec.swift
+++ b/HeimdallrTests/Core/HeimdallrSpec.swift
@@ -726,8 +726,8 @@ class HeimdallrSpec: QuickSpec {
                     }
                 }
 
-                context("when issueing multiple requests at the same time") {
-                    it("only has the first one make network requests") {
+                context("when authenticating multiple requests at the same time with an expired access token") {
+                    it("only the first one triggers a token refresh") {
                         var firstAuthenticateRequestDone = false
                         var madeNetworkRequestAfterFirstAuthenticateRequestDone = false
                         OHHTTPStubs.stubRequestsPassingTest({ _ in

--- a/HeimdallrTests/Core/HeimdallrSpec.swift
+++ b/HeimdallrTests/Core/HeimdallrSpec.swift
@@ -740,12 +740,12 @@ class HeimdallrSpec: QuickSpec {
 
                         waitUntil { done in
                             var firstFinished = false
-                            heimdallr.authenticateRequest(request) {
-                                result = $0
+                            heimdallr.authenticateRequest(request) { incomingResult in
+                                result = incomingResult
                                 firstFinished ? done() : (firstFinished = true)
                             }
-                            heimdallr.authenticateRequest(request) {
-                                result = $0
+                            heimdallr.authenticateRequest(request) { incomingResult in
+                                result = incomingResult
                                 firstFinished ? done() : (firstFinished = true)
                             }
                         }


### PR DESCRIPTION
## Description

Making multiple calls to `authenticateRequest` with an expired access token can lead to multiple requests for a new access token with the same refresh token. As a result, the user might be left with an invalid token.

In order to prevent this, we decided to make calls to `authenticateRequest` sequential. This is achieved by using a serial queue and limiting its resources via a semaphore.
