### PR TITLE
Make OAuthAccessTokenParser objc compatible

### DIFF
--- a/Heimdallr/Core/Heimdallr.swift
+++ b/Heimdallr/Core/Heimdallr.swift
@@ -60,7 +60,7 @@ public let HeimdallrErrorNotAuthorized = 2
     ///
     /// - returns: A new client initialized with the given token endpoint URL,
     ///     credentials and access token store.
-    public init(tokenURL: NSURL, credentials: OAuthClientCredentials? = nil, accessTokenStore: OAuthAccessTokenStore = OAuthAccessTokenKeychainStore(), accessTokenParser: OAuthAccessTokenParser = OAuthAccessTokenDefaultParser(), httpClient: HeimdallrHTTPClient = HeimdallrHTTPClientNSURLSession(), resourceRequestAuthenticator: HeimdallResourceRequestAuthenticator = HeimdallResourceRequestAuthenticatorHTTPAuthorizationHeader()) {
+    @objc public init(tokenURL: NSURL, credentials: OAuthClientCredentials? = nil, accessTokenStore: OAuthAccessTokenStore = OAuthAccessTokenKeychainStore(), accessTokenParser: OAuthAccessTokenParser = OAuthAccessTokenDefaultParser(), httpClient: HeimdallrHTTPClient = HeimdallrHTTPClientNSURLSession(), resourceRequestAuthenticator: HeimdallResourceRequestAuthenticator = HeimdallResourceRequestAuthenticatorHTTPAuthorizationHeader()) {
         self.tokenURL = tokenURL
         self.credentials = credentials
         self.accessTokenStore = accessTokenStore
@@ -143,7 +143,8 @@ public let HeimdallrErrorNotAuthorized = 2
             if let error = error {
                 completion(.Failure(error))
             } else if (response as! NSHTTPURLResponse).statusCode == 200 {
-                switch self.accessTokenParser.parse(data!) {
+                let accessTokenResult = materialize { try self.accessTokenParser.parse(data!) }
+                switch accessTokenResult {
                 case let .Success(accessToken):
                     self.accessToken = accessToken
                     completion(.Success(accessToken))

--- a/Heimdallr/Core/OAuthAccessTokenDefaultParser.swift
+++ b/Heimdallr/Core/OAuthAccessTokenDefaultParser.swift
@@ -1,16 +1,13 @@
 import Foundation
 import Result
 
-@objc
-public class OAuthAccessTokenDefaultParser: NSObject, OAuthAccessTokenParser {
-    public func parse(data: NSData) -> Result<OAuthAccessToken, NSError> {
-        
-        if let token = OAuthAccessToken.decode(data: data) {
-            return .Success(token)
-        } else {
-            let error = NSError(domain: HeimdallrErrorDomain, code: HeimdallrErrorInvalidData, userInfo: nil)
-            return .Failure(error)
+@objc public class OAuthAccessTokenDefaultParser: NSObject, OAuthAccessTokenParser {
+    public func parse(data: NSData) throws -> OAuthAccessToken {
+
+        guard let token = OAuthAccessToken.decode(data: data) else {
+            throw NSError(domain: HeimdallrErrorDomain, code: HeimdallrErrorInvalidData, userInfo: nil)
         }
+
+        return token
     }
 }
-

--- a/Heimdallr/Core/OAuthAccessTokenParser.swift
+++ b/Heimdallr/Core/OAuthAccessTokenParser.swift
@@ -2,6 +2,6 @@ import Foundation
 import Result
 
 /// An access token parser that can be used by Heimdallr.
-public protocol OAuthAccessTokenParser {
-    func parse(data: NSData) -> Result<OAuthAccessToken, NSError>
+@objc public protocol OAuthAccessTokenParser {
+    func parse(data: NSData) throws -> OAuthAccessToken
 }

--- a/HeimdallrTests/Core/HeimdallrSpec.swift
+++ b/HeimdallrTests/Core/HeimdallrSpec.swift
@@ -43,20 +43,20 @@ class OAuthAccessTokenInterceptorParser: OAuthAccessTokenParser {
         interceptError = error
     }
     
-    func parse(data: NSData) -> Result<OAuthAccessToken, NSError> {
+    @objc func parse(data: NSData) throws -> OAuthAccessToken {
         
         timesCalled += 1
         
         if self.shouldIntercept {
             if let accessToken = self.interceptToken {
-                return .Success(accessToken)
+                return accessToken
             } else if let error = self.interceptError {
-                return .Failure(error)
+                throw error
             } else {
                 fatalError("Missing intercept token or error")
             }
         } else {
-            return defaultParser.parse(data)
+            return try defaultParser.parse(data)
         }
     }
     


### PR DESCRIPTION
### Description:

With merging #79 we accidentally broke objc compatibility because of the newly introduced `OAuthAccessTokenParser` that exposes the `Result` type in our initializer.

### Proposed solution:

I've changed the signature of `OAuthAccessTokenParser` to `throw` instead of returning `Result`

```swift
@objc public protocol OAuthAccessTokenParser {
    func parse(data: NSData) throws -> OAuthAccessToken
}
```

fyi: @poislagarde 