### PR TITLE
Bump CircleCI Xcode version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: 8.0
+    version: 8.2
 
 dependencies:
   override:


### PR DESCRIPTION
Bump the CircleCI Xcode version because builds are failing on CI.

```
❌  /Users/distiller/Library/Developer/Xcode/DerivedData/Heimdallr-bcdikrmnkjplubhdnenbogfiharz/Build/Products/Debug-iphonesimulator/ReactiveHeimdallr.framework/Headers/ReactiveHeimdallr-Swift.h:271:4: expected a type

- (RACSignal<RACUnit *> * _Nonnull)rac_requestAccessTokenWithUsername:(NSString * _Nonnull)username password:(NSString * _Nonnull)password;
        ^
```