### PR TITLE
Remove `NS` prefix if appropriate

### DIFF
--- a/Heimdallr/Core/Heimdallr.swift
+++ b/Heimdallr/Core/Heimdallr.swift
@@ -53,14 +53,14 @@ public let HeimdallrErrorNotAuthorized = 2
     /// - parameter accessTokenParser: The access token response parser.
     ///     Default: `OAuthAccessTokenDefaultParser`.
     /// - parameter httpClient: The HTTP client that should be used for requesting
-    ///     access tokens. Default: `HeimdallrHTTPClientNSURLSession`.
+    ///     access tokens. Default: `HeimdallrHTTPClientURLSession`.
     /// - parameter resourceRequestAuthenticator: The request authenticator that is 
     ///     used to authenticate requests. Default: 
     ///     `HeimdallResourceRequestAuthenticatorHTTPAuthorizationHeader`.
     ///
     /// - returns: A new client initialized with the given token endpoint URL,
     ///     credentials and access token store.
-    @objc public init(tokenURL: URL, credentials: OAuthClientCredentials? = nil, accessTokenStore: OAuthAccessTokenStore = OAuthAccessTokenKeychainStore(), accessTokenParser: OAuthAccessTokenParser = OAuthAccessTokenDefaultParser(), httpClient: HeimdallrHTTPClient = HeimdallrHTTPClientNSURLSession(), resourceRequestAuthenticator: HeimdallResourceRequestAuthenticator = HeimdallResourceRequestAuthenticatorHTTPAuthorizationHeader()) {
+    @objc public init(tokenURL: URL, credentials: OAuthClientCredentials? = nil, accessTokenStore: OAuthAccessTokenStore = OAuthAccessTokenKeychainStore(), accessTokenParser: OAuthAccessTokenParser = OAuthAccessTokenDefaultParser(), httpClient: HeimdallrHTTPClient = HeimdallrHTTPClientURLSession(), resourceRequestAuthenticator: HeimdallResourceRequestAuthenticator = HeimdallResourceRequestAuthenticatorHTTPAuthorizationHeader()) {
         self.tokenURL = tokenURL
         self.credentials = credentials
         self.accessTokenStore = accessTokenStore

--- a/Heimdallr/Core/HeimdallrHTTPClientNSURLSession.swift
+++ b/Heimdallr/Core/HeimdallrHTTPClientNSURLSession.swift
@@ -1,17 +1,17 @@
 import Foundation
 
-/// An HTTP client that uses NSURLSession.
+/// An HTTP client that uses URLSession.
 @objc
-public class HeimdallrHTTPClientNSURLSession: NSObject, HeimdallrHTTPClient {
+public class HeimdallrHTTPClientURLSession: NSObject, HeimdallrHTTPClient {
 
     let urlSession: URLSession
 
     /// Initializes a new client.
     ///
     /// - parameter urlSession: The NSURLSession to use.
-    ///     Default: `NSURLSession(configuration: NSURLSessionConfiguration.defaultSessionConfiguration())`.
+    ///     Default: `URLSession(configuration: URLSessionConfiguration.defaultSessionConfiguration())`.
     ///
-    /// - returns: A new client using the given `NSURLSession`.
+    /// - returns: A new client using the given `URLSession`.
     public init(urlSession: URLSession = URLSession(configuration: URLSessionConfiguration.default)) {
         self.urlSession = urlSession
     }

--- a/Heimdallr/Core/OAuthAccessToken.swift
+++ b/Heimdallr/Core/OAuthAccessToken.swift
@@ -57,7 +57,7 @@ public func == (lhs: OAuthAccessToken, rhs: OAuthAccessToken) -> Bool {
 
 extension OAuthAccessToken {
     public class func decode(_ json: [String: AnyObject]) -> OAuthAccessToken? {
-        func toNSDate(_ timeIntervalSinceNow: TimeInterval?) -> Date? {
+        func toDate(_ timeIntervalSinceNow: TimeInterval?) -> Date? {
             return timeIntervalSinceNow.map { timeIntervalSinceNow in
                 return Date(timeIntervalSinceNow: timeIntervalSinceNow)
             }
@@ -68,7 +68,7 @@ extension OAuthAccessToken {
             return nil
         }
 
-        let expiresAt = (json["expires_in"] as? TimeInterval).flatMap(toNSDate)
+        let expiresAt = (json["expires_in"] as? TimeInterval).flatMap(toDate)
         let refreshToken = json["refresh_token"] as? String
 
         return OAuthAccessToken(accessToken: accessToken, tokenType: tokenType,

--- a/Heimdallr/Core/OAuthAccessTokenKeychainStore.swift
+++ b/Heimdallr/Core/OAuthAccessTokenKeychainStore.swift
@@ -31,7 +31,7 @@ internal struct Keychain {
 
     internal func valueForKey(_ key: String) -> String? {
         return dataForKey(key).flatMap { data in
-            return NSString(data: data, encoding: String.Encoding.utf8.rawValue) as? String
+            return String(data: data, encoding: String.Encoding.utf8)
         }
     }
 

--- a/Heimdallr/Core/URLRequestExtensions.swift
+++ b/Heimdallr/Core/URLRequestExtensions.swift
@@ -21,7 +21,7 @@ public enum HTTPAuthentication: Equatable {
         case .basicAuthentication(let username, let password):
             if let credentials = "\(username):\(password)"
                 .data(using: String.Encoding.ascii)?
-                .base64EncodedString(options: NSData.Base64EncodingOptions(rawValue: 0)) {
+                .base64EncodedString(options: Data.Base64EncodingOptions(rawValue: 0)) {
                 return "Basic \(credentials)"
             } else {
                 return nil

--- a/HeimdallrTests/Core/URLRequestExtensionsSpec.swift
+++ b/HeimdallrTests/Core/URLRequestExtensionsSpec.swift
@@ -150,7 +150,7 @@ class URLRequestExtensionsSpec: QuickSpec {
 
                     request.setHTTPBody(parameters: parameters)
 
-                    let components = NSString(data: request.httpBody!, encoding: String.Encoding.utf8.rawValue)?
+                    let components = String(data: request.httpBody!, encoding: String.Encoding.utf8)?
                         .components(separatedBy: "&")
                         .sorted { $0 < $1 }
 


### PR DESCRIPTION
In order to extend the swift 3 migration, I have removed the `NS` prefix if appropriate.

This means from following classes:
* `NSString`
* `NSData`
* `NSDate`
* `NSURLSession`
* `HeimdallrHTTPClientNSURLSession`

I do not have touched `Heimdallr+ReactiveCocoa.swift`.