### PR TITLE
Add support for SwiftPackageManager for macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ xcuserdata
 
 # Carthage
 Carthage/
+
+Package.resolved
+.build/

--- a/Heimdallr/Heimdallr.swift
+++ b/Heimdallr/Heimdallr.swift
@@ -11,7 +11,7 @@ public let HeimdallrErrorNotAuthorized = 2
 
 /// The all-seeing and all-hearing guardian sentry of your application who
 /// stands on the rainbow bridge network to authorize relevant requests.
-@objc open class Heimdallr: NSObject {
+open class Heimdallr: NSObject {
     public let tokenURL: URL
     private let credentials: OAuthClientCredentials?
 

--- a/Heimdallr/HeimdallrHTTPClientURLSession.swift
+++ b/Heimdallr/HeimdallrHTTPClientURLSession.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 /// An HTTP client that uses URLSession.
-@objc
 public class HeimdallrHTTPClientURLSession: NSObject, HeimdallrHTTPClient {
 
     let urlSession: URLSession

--- a/Heimdallr/HeimdallrResourceRequestAuthenticatorHTTPAuthorizationHeader.swift
+++ b/Heimdallr/HeimdallrResourceRequestAuthenticatorHTTPAuthorizationHeader.swift
@@ -2,7 +2,6 @@ import Foundation
 
 /// A `HeimdallResourceRequestAuthenticator` which uses the HTTP `Authorization`
 /// Header to authorize a request.
-@objc
 public class HeimdallResourceRequestAuthenticatorHTTPAuthorizationHeader: NSObject, HeimdallResourceRequestAuthenticator {
 
     public override init() {

--- a/Heimdallr/OAuthAccessToken.swift
+++ b/Heimdallr/OAuthAccessToken.swift
@@ -1,7 +1,7 @@
+import Foundation
 import Result
 
 /// An access token is used for authorizing requests to the resource endpoint.
-@objc
 public class OAuthAccessToken: NSObject {
     /// The access token.
     public let accessToken: String

--- a/Heimdallr/OAuthAccessTokenDefaultParser.swift
+++ b/Heimdallr/OAuthAccessTokenDefaultParser.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Result
 
-@objc public class OAuthAccessTokenDefaultParser: NSObject, OAuthAccessTokenParser {
+public class OAuthAccessTokenDefaultParser: NSObject, OAuthAccessTokenParser {
     public func parse(data: Data) throws -> OAuthAccessToken {
 
         guard let token = OAuthAccessToken.decode(data: data) else {

--- a/Heimdallr/OAuthAccessTokenKeychainStore.swift
+++ b/Heimdallr/OAuthAccessTokenKeychainStore.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Security
 
 internal struct Keychain {
@@ -90,7 +91,7 @@ internal struct Keychain {
 }
 
 /// A persistent keychain-based access token store.
-@objc public class OAuthAccessTokenKeychainStore: NSObject, OAuthAccessTokenStore {
+public class OAuthAccessTokenKeychainStore: NSObject, OAuthAccessTokenStore {
     private var keychain: Keychain
 
     /// Creates an instance initialized to the given keychain service.

--- a/Heimdallr/OAuthClientCredentials.swift
+++ b/Heimdallr/OAuthClientCredentials.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 /// Client credentials are used for authenticating with the token endpoint.
-@objc
 public class OAuthClientCredentials: NSObject {
     /// The client identifier.
     public let id: String

--- a/Heimdallr/OAuthError.swift
+++ b/Heimdallr/OAuthError.swift
@@ -1,6 +1,9 @@
 /// See: The OAuth 2.0 Authorization Framework, 5.2 NSError Response
 ///      <https://tools.ietf.org/html/rfc6749#section-5.2>
 
+
+import Foundation
+
 public let OAuthErrorDomain = "OAuthErrorDomain"
 public let OAuthErrorInvalidRequest = 1
 public let OAuthErrorInvalidClient = 2

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:4.0
+import PackageDescription
+
+let package = Package(
+    name: "Heimdallr",
+    products: [
+        .library(name: "Heimdallr", targets: ["Heimdallr"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/antitypical/Result.git", .upToNextMajor(from: "3.0.0")),
+    ],
+    targets: [
+         .target(
+            name: "Heimdallr",
+            dependencies: ["Result"],
+			path: "Heimdallr",
+            exclude: [
+                "HeimdallrTests",
+                "script",
+                "Carthage",
+				"Heimdallr/Supporting Files",
+                "bin"]),
+    ],
+    swiftLanguageVersions: [3]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -13,12 +13,12 @@ let package = Package(
          .target(
             name: "Heimdallr",
             dependencies: ["Result"],
-			path: "Heimdallr",
+            path: "Heimdallr",
             exclude: [
                 "HeimdallrTests",
                 "script",
                 "Carthage",
-				"Heimdallr/Supporting Files",
+                "Heimdallr/Supporting Files",
                 "bin"]),
     ],
     swiftLanguageVersions: [3]


### PR DESCRIPTION
This PR add support for [Swift Package Manager](https://github.com/apple/swift-package-manager)(SPM) and fix https://github.com/trivago/Heimdallr.swift/issues/112

Remove `@objc` and adding missing `import`