### PR TITLE
Use `Result` in Swift standard library instead of  from a dependency.

### DIFF
--- a/Heimdallr.podspec
+++ b/Heimdallr.podspec
@@ -19,11 +19,11 @@ Pod::Spec.new do |spec|
 
   spec.ios.deployment_target = '9.0'
   spec.osx.deployment_target = '10.10'
+  spec.swift_version = '5.0'
 
   spec.default_subspec = 'Core'
 
   spec.subspec 'Core' do |subspec|
-    subspec.dependency 'Result', '~> 4.1.0'
     subspec.framework = 'Foundation'
 
     subspec.source_files = 'Heimdallr/*.swift'

--- a/Heimdallr/OAuthAccessToken.swift
+++ b/Heimdallr/OAuthAccessToken.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Result
 
 /// An access token is used for authorizing requests to the resource endpoint.
 @objc

--- a/Heimdallr/OAuthAccessTokenDefaultParser.swift
+++ b/Heimdallr/OAuthAccessTokenDefaultParser.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Result
 
 @objc public class OAuthAccessTokenDefaultParser: NSObject, OAuthAccessTokenParser {
     public func parse(data: Data) throws -> OAuthAccessToken {

--- a/Heimdallr/OAuthAccessTokenParser.swift
+++ b/Heimdallr/OAuthAccessTokenParser.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Result
 
 /// An access token parser that can be used by Heimdallr.
 @objc public protocol OAuthAccessTokenParser {


### PR DESCRIPTION
Since Swift 5.0 we can use `Result` from standard library. There is no need for adding a `Result` module from dependency.